### PR TITLE
channeld: initialize tx_sigs_allowed on startup

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -7032,6 +7032,7 @@ int main(int argc, char *argv[])
 	peer->commit_timer = NULL;
 	peer->from_master = msg_queue_new(peer, true);
 	peer->shutdown_sent[LOCAL] = false;
+	peer->tx_sigs_allowed = false;
 	peer->shutdown_wrong_funding = NULL;
 	peer->last_update_timestamp = 0;
 	peer->last_empty_commitment = 0;


### PR DESCRIPTION
`peer->tx_sigs_allowed` was only set in `peer_reconnect()` and when we receive `channel_ready`, so on a fresh channeld start a stray `tx_signatures` arriving before the peer's `channel_ready` made `handle_unexpected_tx_sigs(`) read an uninitialized `bool`.  `UBSan` flags this as a load of an invalid bool value, and in normal builds the "warn and disconnect" branch was effectively taken at random.

Default it to false: we only allow an unexpected `tx_signatures` when reconnecting.

Changelog-None

I've found this issue using Smite. 

The Impact is minimal: the flag only decides whether one unexpected `tx_signatures` is logged and dropped, or answered with a warning and a disconnect.  The message is never acted on either way, so no channel state or funds are affected; the worst case is that a peer gets one stray message ignored instead of being disconnected.
