### PR TITLE
dualopend: initialize state->reconnected on startup

### DIFF
--- a/openingd/dualopend.c
+++ b/openingd/dualopend.c
@@ -4325,8 +4325,9 @@ int main(int argc, char *argv[])
 	 * writing to REQ_FD */
 	status_setup_sync(REQ_FD);
 
-	/* Init state to not aborted */
+	/* Init state to not aborted, and not reconnected until we know better */
 	state->aborted_err = NULL;
+	state->reconnected = false;
 
 	/*~ The very first thing we read from lightningd is our init msg */
 	msg = wire_sync_read(tmpctx, REQ_FD);


### PR DESCRIPTION
`state->reconnected` was only set to true after `do_reconnect_dance()`, so a fresh dualopend never wrote it.  A `commitment_signed` arriving out of turn in the main loop made `handle_commit_signed()` read an uninitialized bool, which UBSan flags as a load of an invalid bool value.

Default it to false, so an out-of-turn `commitment_signed` is always rejected unless we really reconnected.

Changelog-None

Found this issue using Smite. Severity is low.