### PR TITLE
bitcoind: fix byte order of block hash from getrawblockbyheight

### DIFF
--- a/lightningd/bitcoind.c
+++ b/lightningd/bitcoind.c
@@ -446,7 +446,7 @@ getrawblockbyheight_callback(const char *buf, const jsmntok_t *toks,
 	}
 
 	err = json_scan(tmpctx, buf, resulttok, "{blockhash:%,block:%}",
-			JSON_SCAN(json_to_sha256, &blkid.shad.sha),
+			JSON_SCAN(json_to_bitcoin_blkid, &blkid),
 			JSON_SCAN_TAL(tmpctx, json_strdup, &block_str));
 	if (err)
 		bitcoin_plugin_error(call->bitcoind, buf, resulttok,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -87,6 +87,9 @@ def test_block_backfill(node_factory, bitcoind, chainparams):
     heights = [r['height'] for r in l3.db_query("SELECT height FROM blocks")]
     assert(103 in heights)
 
+    stored_hash = only_one(l3.db_query("SELECT hash FROM blocks WHERE height = 103"))['hash']
+    assert bytes(stored_hash) == bytes.fromhex(bitcoind.rpc.getblockhash(103))[::-1]
+
     # Make sure we also have the needle we added to the haystack above
     assert(31337 in [r['satoshis'] for r in l3.db_query("SELECT satoshis FROM utxoset")])
 


### PR DESCRIPTION
Fixes #9465 

**Summary**

`getrawblockbyheight_callback()` parsed the plugin s `blockhash` field with `json_to_sha256()`, which hex-decodes without reversing bytes. Every other block hash / txid parser in the codebase (like `bitcoin_blkid_from_hex`, `bitcoin_txid_from_hex`, `json_to_bitcoin_blkid`) reverses the bytes after decoding, since bitcoind displays hashes in rpc/json in the opposite byte order to the internal representation used for hashing and db storage

Most callers of `bitcoind_getrawblockbyheight()` ignore the parsed `blkid` and recompute it from the block header instead, so they were unaffected. But `process_getfilteredblock_step1()` (used for on-demand gossip block backfill) trusts the parsed value directly, and `wallet_filteredblock_add()` writes it straight into `blocks.hash` - producing rows with inconsistent endianness relative to rows written by normal chain-tip sync

**Fix**

Parse `blockhash` with `json_to_bitcoin_blkid()` instead, matching every other blkid parser in the codebase



Changelog-None

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
