### PR TITLE
db: fix intvars being truncated to 32 bits on write and read

### DIFF
--- a/db/exec.c
+++ b/db/exec.c
@@ -50,7 +50,7 @@ u32 db_data_version_get(struct db *db)
 	}
 	/* This fails on uninitialized db, so "0" */
 	if (db_step(stmt))
-		version = db_col_int(stmt, "intval");
+		version = db_col_s64(stmt, "intval");
 	else
 		version = 0;
 	tal_free(stmt);
@@ -61,7 +61,7 @@ void db_set_intvar(struct db *db, const char *varname, s64 val)
 {
 	size_t changes;
 	struct db_stmt *stmt = db_prepare_v2(db, SQL("UPDATE vars SET intval=? WHERE name=?;"));
-	db_bind_int(stmt, val);
+	db_bind_s64(stmt, val);
 	db_bind_text(stmt, varname);
 	db_exec_prepared_v2(stmt);
 	changes = db_count_changes(stmt);
@@ -70,7 +70,7 @@ void db_set_intvar(struct db *db, const char *varname, s64 val)
 	if (changes == 0) {
 		stmt = db_prepare_v2(db, SQL("INSERT INTO vars (name, intval) VALUES (?, ?);"));
 		db_bind_text(stmt, varname);
-		db_bind_int(stmt, val);
+		db_bind_s64(stmt, val);
 		db_exec_prepared_v2(stmt);
 		tal_free(stmt);
 	}
@@ -83,7 +83,7 @@ s64 db_get_intvar(struct db *db, const char *varname, s64 defval)
 	    db, SQL("SELECT intval FROM vars WHERE name= ? LIMIT 1"));
 	db_bind_text(stmt, varname);
 	if (db_query_prepared_canfail(stmt) && db_step(stmt))
-		res = db_col_int(stmt, "intval");
+		res = db_col_s64(stmt, "intval");
 
 	tal_free(stmt);
 	return res;

--- a/wallet/migrations.c
+++ b/wallet/migrations.c
@@ -1187,6 +1187,9 @@ static const struct db_migration dbmigrations[] = {
     {SQL("ALTER TABLE payments ADD failmsg BLOB;"), NULL,
      SQL("ALTER TABLE payments DROP COLUMN failmsg"), NULL},
     /* ^v26.09 */
+
+    {SQL("/*PSQL*/ALTER TABLE vars ALTER COLUMN intval TYPE BIGINT"), NULL,
+     SQL("/*PSQL*/ALTER TABLE vars ALTER COLUMN intval TYPE INTEGER"), NULL},
 };
 
 const struct db_migration *get_db_migrations(size_t *num)

--- a/wallet/test/run-db.c
+++ b/wallet/test/run-db.c
@@ -502,6 +502,9 @@ static bool test_vars(struct lightningd *ld)
 	/* Check updating */
 	db_set_intvar(db, varname, 2);
 	CHECK(db_get_intvar(db, varname, 42) == 2);
+
+	db_set_intvar(db, varname, 10000000000LL);
+	CHECK(db_get_intvar(db, varname, 42) == 10000000000LL);
 	db_commit_transaction(db);
 
 	tal_free(db);


### PR DESCRIPTION
Fixes #9467 

What changed
- `db/exec.c` - `db_set_intvar`, `db_get_intvar`, and `db_data_version_get` (reads the same column) now use the existing 64-bit `db_bind_s64`/`db_col_s64` helpers instead of the 32-bit ones

- `wallet/migrations.c` - new migration widens `vars.intval` to `BIGINT` on Postgres only (/*PSQL*/ no-op on SQLite, which doesnt enforce column width), with a matching revert

- `wallet/test/run-db.c` - added a regression case round-tripping a value >32 bits, verified it fails on the old code and passes with the fix


Changelog-Fixed: db: fixed vars table integers being truncated to 32 bits

> [!IMPORTANT]
>
> 26.09 FREEZE August 5th: Non-bugfix PRs not ready by this date will wait for 26.12.
>
> RC1 is scheduled on _August 17th_
>
> The final release is scheduled for September 7th.


## Checklist
Before submitting the PR, ensure the following tasks are completed. If an item is not applicable to your PR, please mark it as checked:

- [ ] The changelog has been updated in the relevant commit(s) according to the [guidelines](https://docs.corelightning.org/docs/coding-style-guidelines#changelog-entries-in-commit-messages).
- [ ] Tests have been added or modified to reflect the changes.
- [ ] Documentation has been reviewed and updated as needed.
- [ ] Related issues have been listed and linked, including any that this PR closes.
- [ ] *Important* All PRs must consider how to reverse any persistent changes for `tools/lightning-downgrade`
